### PR TITLE
feat: Allow injection of a different base host url and custom headers

### DIFF
--- a/Sources/OpenAIKit/Configuration.swift
+++ b/Sources/OpenAIKit/Configuration.swift
@@ -5,7 +5,7 @@ public struct Configuration {
     public let apiKey: String
     public let organization: String?
     public let host: String
-    var headers: HTTPHeaders
+    let headers: HTTPHeaders
     
     public init(
         apiKey: String,

--- a/Sources/OpenAIKit/Configuration.swift
+++ b/Sources/OpenAIKit/Configuration.swift
@@ -1,10 +1,22 @@
 import NIOHTTP1
+import Foundation
 
 public struct Configuration {
     public let apiKey: String
     public let organization: String?
+    public let host: String
+    var headers: HTTPHeaders
     
-    var headers: HTTPHeaders {
+    public init(
+        apiKey: String,
+        organization: String? = nil,
+        host: String = "api.openai.com",
+        customHeaders: [String: String] = [:]
+    ) {
+        self.apiKey = apiKey
+        self.organization = organization
+        self.host = host
+        
         var headers = HTTPHeaders()
         headers.add(name: "Authorization", value: "Bearer \(apiKey)")
 
@@ -12,15 +24,10 @@ public struct Configuration {
             headers.add(name: "OpenAI-Organization", value: organization)
         }
         
-        return headers
+        customHeaders.keys.forEach { key in
+            headers.add(name: key, value: customHeaders[key] ?? "")
+        }
+        
+        self.headers = headers
     }
-    
-    public init(
-        apiKey: String,
-        organization: String? = nil
-    ) {
-        self.apiKey = apiKey
-        self.organization = organization
-    }
-    
 }

--- a/Sources/OpenAIKit/Request Handler/Request.swift
+++ b/Sources/OpenAIKit/Request Handler/Request.swift
@@ -5,7 +5,6 @@ import Foundation
 protocol Request {
     var method: HTTPMethod { get }
     var scheme: String { get }
-    var host: String { get }
     var path: String { get }
     var body: Data? { get }
     var headers: HTTPHeaders { get }
@@ -17,7 +16,6 @@ extension Request {
     static var encoder: JSONEncoder { .requestEncoder }
 
     var scheme: String { "https" }
-    var host: String { "api.openai.com" }
     var body: Data? { nil }
     
     var headers: HTTPHeaders {

--- a/Sources/OpenAIKit/Request Handler/RequestHandler.swift
+++ b/Sources/OpenAIKit/Request Handler/RequestHandler.swift
@@ -23,7 +23,7 @@ struct RequestHandler {
     func generateURL(for request: Request) throws -> String {
         var components = URLComponents()
         components.scheme = request.scheme
-        components.host = request.host
+        components.host = configuration.host
         components.path = request.path
             
         guard let url = components.url else {


### PR DESCRIPTION
This PR changes the code to allow us pass a different Open AI api host and also to inject custom headers.